### PR TITLE
Fix path to the respective go example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following is the suggested reading order:
   1. [Structs](structures/structs.go)
   1. [Methods and receivers](structures/methods.go)
   1. [Interfaces](variablestypes/interfaces.go)
-  1. [Tags](variablestypes/tags.go)
+  1. [Tags](structures/tags.go)
   
  ## Error handling
  


### PR DESCRIPTION
Point to the correct resource.